### PR TITLE
Update typography: Implement Serif+Sans-Serif font pairing.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,6 +1,8 @@
+@import url('https://fonts.googleapis.com/css2?family=Merriweather:ital,wght@0,300;0,400;0,700;0,900;1,300;1,400;1,700;1,900&family=Open+Sans:ital,wght@0,300..800;1,300..800&display=swap');
+
 body {
-    font-family: 'Roboto', sans-serif;
-    background-color: #f5f5f5;
+    font-family: 'Open Sans', sans-serif;
+    background-image: linear-gradient(to bottom right, #aec6cf, #e0e0e0);
     color: #333;
     line-height: 1.6;
 }
@@ -88,7 +90,7 @@ body {
 }
 
 h1, h2, h3, h4, h5, h6 {
-	font-family: 'Lora', serif;
+	font-family: 'Merriweather', serif;
 	color: #2c3e50;
 }
 
@@ -118,7 +120,7 @@ h1, h2, h3, h4, h5, h6 {
 
 p {
 	/*font-family: "Montserrat", sans-serif;*/
-	font-family: "Roboto", sans-serif;
+	font-family: 'Open Sans', sans-serif;
 }
 
 a {
@@ -136,7 +138,7 @@ a:focus {
 	color: black;
 	padding: 10px;
 	margin-left: 25px ;
-	font-family: "Montserrat";
+	font-family: 'Open Sans', sans-serif;
 	font-weight:400;
     margin-top: 0px;
 }
@@ -145,7 +147,7 @@ a:focus {
 	color: black;
 	padding: 10px;
 	margin-left: 30px ;
-	font-family: "Montserrat";
+	font-family: 'Open Sans', sans-serif;
 	font-weight:400;
 }
 
@@ -153,7 +155,7 @@ a:focus {
 	margin-top: 35px;
   margin-bottom:35px;
 	display: inline-block;
-	font-family: "Montserrat";
+	font-family: 'Open Sans', sans-serif;
 }
 
 #profile_pic{
@@ -196,7 +198,7 @@ a:focus {
 	padding: 10px 0px 0px 40px;
 	margin: 5px;
 	font-size: 18px;
-	font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+	font-family: 'Open Sans', sans-serif;
 	font-weight: 300;
 	border-radius: 3px;
 }
@@ -217,7 +219,7 @@ a:focus {
 	padding: 10px 0px 0px 40px;
 	margin: 10px;
 	font-size: 21px;
-	font-family: 'Montserrat', sans-serif /*'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;*/
+	font-family: 'Open Sans', sans-serif;
 	font-weight: 300;
 	border-radius: 3px;
 }
@@ -228,7 +230,7 @@ a:focus {
 	padding: 10px 0px 0px 30px;
 	margin: 15px;
 	font-size: 18px;
-	font-family: "Montserrat";
+	font-family: 'Open Sans', sans-serif;
 	font-weight: 300;
 	border-radius: 3px;
 }
@@ -238,7 +240,6 @@ h1 {
 	display: block;
 	padding: 10px 10px 10px 30px;
 	font-size: 60px;
-	font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 	font-weight:300;
 	margin: 15px;
     margin-top: 0;
@@ -251,7 +252,7 @@ h1 {
 	padding: 10px 10px 10px 30px;
 	margin: 15px;
 	font-size: 15px;
-	font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+	font-family: 'Open Sans', sans-serif;
 	font-weight:300;
 	width: fit-content;
 }


### PR DESCRIPTION
Set Merriweather as the font for all headings (h1-h6) and Open Sans for the body text. This enhances readability and provides a classic, clean aesthetic across the website. Imported necessary fonts from Google Fonts.